### PR TITLE
rarbgapi: add support for searching by show/movie ID

### DIFF
--- a/rarbgapi/rarbgapi.py
+++ b/rarbgapi/rarbgapi.py
@@ -123,7 +123,8 @@ class _RarbgAPIv2(object):
         }
         for key, value in kwargs.items():
             if key not in ['search_string', 'sort', 'limit',
-                           'category', 'format_']:
+                           'category', 'format_', 'search_imdb',
+                           'search_tvdb', 'search_themoviedb']:
                 raise ValueError('unsupported parameter %s' % key)
 
             if key == 'format_':


### PR DESCRIPTION
E.g. to search a TV show using the TheTVDB ID the `search_tvdb` argument can be passed to the `search` function.
Supported are: `search_imdb`, `search_tvdb` and `search_themoviedb`