### PR TITLE
Fix slight typo in category search example

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Search torrents with specific keyword or imdb, tvdb and themoviedb index via `se
 
 or specific category
 ``` python
->>> client.search(search_string="walking dead", category=RarbgAPI.CATEGORY_TV_EPISODES)
+>>> client.search(search_string="walking dead", category=rarbgapi.RarbgAPI.CATEGORY_TV_EPISODES)
 ```
 
 ## options


### PR DESCRIPTION
The examples import rarbgapi directly.

Categories is under rarbgapi.RarbgAPI.CATEGORY_* - this update makes the examples as given on this page.